### PR TITLE
fix : 修复Ingess  中的 tls 不生效

### DIFF
--- a/charts/hertzbeat/templates/manager/ingress.yaml
+++ b/charts/hertzbeat/templates/manager/ingress.yaml
@@ -21,7 +21,7 @@ spec:
                   number: 1157
   tls:
     {{- if .Values.expose.ingress.tls.enabled }}
-    - secretName: {{ .Values.expose.ingress.tls.secretName }}
+    - secretName: {{ .Values.expose.ingress.tls.tls.secretName }}
       hosts:
         - {{ .Values.expose.ingress.host }}
     {{- end }}

--- a/charts/hertzbeat/values.yaml
+++ b/charts/hertzbeat/values.yaml
@@ -123,4 +123,4 @@ expose:
     tls:
       enabled: false
       tls:
-        - secretName: your-tls-secret 
+        secretName: your-tls-secret


### PR DESCRIPTION
hertzbeat.manager.ingress中的路径错误